### PR TITLE
Remove `unique_constraints` and `order_by` properties for `InfraPrefix` Node kind

### DIFF
--- a/models/infrastructure.yml
+++ b/models/infrastructure.yml
@@ -812,12 +812,12 @@ nodes:
     label: "Prefix"
     default_filter: prefix__value
     order_by:
-      - vrf__name__value
+      # - vrf__name__value
       - prefix__value
     display_labels:
       - prefix__value
-    uniqueness_constraints:
-        - [ "vrf", "prefix__value"]
+    # uniqueness_constraints:
+    #     - [ "vrf", "prefix__value"]
     attributes:
       - name: prefix
         kind: IPNetwork


### PR DESCRIPTION
In #16 new unique constraints and order_by properties were set for the `InfraPrefix` kind

This change seemed to trigger https://github.com/opsmill/infrahub/issues/2803, which caused problems when using the `generate_network-services.py` generator. 

It would also cause schema integrity checks to fail when creating a proposed change:
![image](https://github.com/opsmill/infrahub-demo-dc-fabric/assets/7521270/d9eb0d7c-3b31-44ef-ab6e-fe27bd1824fd)
![image](https://github.com/opsmill/infrahub-demo-dc-fabric/assets/7521270/e3d6f9e7-cdd1-41ed-990a-42f5236af312)

This PR removes the unique constraint and order_by properties for `InfraPrefix` until we have a solution for https://github.com/opsmill/infrahub/issues/2803